### PR TITLE
EHT-1140 Remove mailfirst flag

### DIFF
--- a/roles/security/templates/logrotate.j2
+++ b/roles/security/templates/logrotate.j2
@@ -33,5 +33,4 @@
 
     # Send an email to team@encapsulate.xyz if an error occurs during rotation
     mail team@encapsulate.xyz
-    mailfirst
 }


### PR DESCRIPTION
It's trying to send the log rotated file via mail, which is the reason behind the garbled emails.